### PR TITLE
Too many 0 events pushed by sniffer

### DIFF
--- a/RPi_utils/Makefile
+++ b/RPi_utils/Makefile
@@ -1,4 +1,4 @@
-all: send codesend RFSniffer
+all: send codesend RFSniffer RFSnifferLoop
 
 send: RCSwitch.o send.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -pthread $+ -o $@ -lwiringPi
@@ -6,9 +6,11 @@ send: RCSwitch.o send.o
 codesend: RCSwitch.o codesend.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -pthread $+ -o $@ -lwiringPi
 	
-RFSniffer: RCSwitch.o RFSniffer.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -pthread $+ -o $@ -lwiringPi
+RFSniffer: RCSwitch.o RFSniffer.o MqttWrapper.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -pthread $+ -o $@ -lwiringPi -lmosquittopp
 	
+RFSnifferLoop: RCSwitch.o RFSnifferLoop.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -pthread $+ -o $@ -lwiringPi
 
 clean:
-	$(RM) *.o send codesend servo RFSniffer
+	$(RM) *.o send codesend RFSniffer RFSnifferLoop

--- a/RPi_utils/MqttWrapper.cpp
+++ b/RPi_utils/MqttWrapper.cpp
@@ -1,0 +1,39 @@
+#include "MqttWrapper.h"
+
+MqttWrapper::MqttWrapper(const char * _id,const char * _topic, const char * _host, int _port) : mosquittopp(_id)
+{
+	mosqpp::lib_init();// Mandatory initialization for mosquitto library
+	this->keepalive = 60;// Basic configuration setup for myMosq class
+	this->status = false;
+	this->id = _id;
+	this->port = _port;
+	this->host = _host;
+	this->topic = _topic;
+	connect(host, port, keepalive);// non blocking connection to broker request
+	loop_start();// Start thread managing connection / publish / subscribe
+};
+
+MqttWrapper::~MqttWrapper() 
+{
+	loop_stop();
+	mosqpp::lib_cleanup();
+};
+
+bool MqttWrapper::send_message(const  char * _message, const char * _topic)
+{
+	int ret = publish(NULL,(_topic != NULL)?_topic:this->topic,strlen(_message),_message,1,false);
+	return ( ret == MOSQ_ERR_SUCCESS );
+};
+
+void MqttWrapper::on_disconnect(int rc) {
+	this->status = false;
+};
+
+void MqttWrapper::on_connect(int rc)
+{
+	this->status = true;
+};
+
+bool MqttWrapper::is_alive(){
+	return this->status;
+};

--- a/RPi_utils/MqttWrapper.h
+++ b/RPi_utils/MqttWrapper.h
@@ -1,0 +1,27 @@
+#ifndef _MQTTWRAPPERH_
+#define _MQTTWRAPPERH_
+
+#include <mosquittopp.h>
+#include <stdio.h>
+#include <string.h>
+
+class MqttWrapper : public mosqpp::mosquittopp
+{
+private:
+	const char* host;
+	const char* id;
+	const char* topic;
+	int port;
+	int keepalive;
+	bool status;
+
+	void on_connect(int rc);
+	void on_disconnect(int rc);
+public:
+	MqttWrapper(const char *id, const char * _topic, const char *host, int port);
+	~MqttWrapper();
+	bool send_message(const char * _message, const char * _topic);
+	bool is_alive();
+};
+
+#endif //_MQTTWRAPPERH_

--- a/RPi_utils/RCSwitch.cpp
+++ b/RPi_utils/RCSwitch.cpp
@@ -518,12 +518,14 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
       RCSwitch::nReceivedBitlength = changeCount / 2;
       RCSwitch::nReceivedDelay = delay;
       RCSwitch::nReceivedProtocol = 1;
-      pushEvent(code);
+      if(code!=0){
+        pushEvent(code);
+      }
     }
 
     if (code == 0){
         return false;
-    }else if (code != 0){
+    }else{
         return true;
     }
 
@@ -555,12 +557,14 @@ bool RCSwitch::receiveProtocol2(unsigned int changeCount){
       RCSwitch::nReceivedBitlength = changeCount / 2;
       RCSwitch::nReceivedDelay = delay;
       RCSwitch::nReceivedProtocol = 2;
-      pushEvent(code);
+      if(code!=0){
+        pushEvent(code);
+      }
     }
 
     if (code == 0){
         return false;
-    }else if (code != 0){
+    }else{
         return true;
     }
 

--- a/RPi_utils/RCSwitch.h
+++ b/RPi_utils/RCSwitch.h
@@ -57,6 +57,7 @@ class RCSwitch {
 
   public:
     static unsigned long popEvent();
+    static void pushEvent(unsigned long);
 
     RCSwitch();
 
@@ -105,8 +106,6 @@ class RCSwitch {
     static unsigned int nReceivedDelay;
     static unsigned int nReceivedProtocol;
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
-
-    static void pushEvent(unsigned long);
 
     static unsigned long events[RCSWITCH_MAX_EVENTS];
     static int eventsHead;

--- a/RPi_utils/README.md
+++ b/RPi_utils/README.md
@@ -10,7 +10,8 @@ the library provided by the arduino.
 ## Usage
 
 First you have to install the [wiringpi](https://projects.drogon.net/raspberry-pi/wiringpi/download-and-install/) library.
-After that you can compile the example program *send* by executing *make*. 
+After that you have to execute : `apt-get install libmosquittopp-dev`.
+Now you can compile the example program *send* by executing *make*. 
 You may want to change the used GPIO pin before compilation of the codesend.cpp source file.
 
 ## Note

--- a/RPi_utils/RFSniffer.cpp
+++ b/RPi_utils/RFSniffer.cpp
@@ -1,27 +1,117 @@
 /*
-  RF_Sniffer
+RF_Sniffer
 
-  Hacked from http://code.google.com/p/rc-switch/
+Hacked from http://code.google.com/p/rc-switch/
 
-  by @justy to provide a handy RF code sniffer
+by @justy to provide a handy RF code sniffer
 */
 
 #include "RCSwitch.h"
+#include "MqttWrapper.h"
+#include "RFSniffer.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <ctype.h>
+#include <time.h>
+#include <pthread.h>
+#include <unistd.h>
 
-// This pin is not the first pin on the RPi GPIO header!
-// Consult https://projects.drogon.net/raspberry-pi/wiringpi/pins/
-// for more information.
-const int PIN = 2;
+unsigned long currentCode = DEFAULT_CODE;
+time_t firstCodeReceivedTime, lastCodeReceivedTime;
 
+/*
+* Usage : ./RFSniffer -b<MQTT Broker> -p<MQTT Port> -t<MQTT Topic>
+*/
 int main(int argc, char *argv[]) {
 
-    if (::wiringPiSetup() == -1) return 1;
+	//Error cases : could not setup wiringPi or bad arguments number
+	if (::wiringPiSetup() == -1 || argc != 4)
+	{
+		return ERROR_RETURN;
+	}
 
-    RCSwitch mySwitch;
-    mySwitch.enableReceive(PIN);  // Receiver on inerrupt 0 => that is pin #2
-    ::printf("%i", RCSwitch::popEvent());
+	//Get the arguments
+	char *mqttBroker = 0;
+	char *mqttTopic = 0;
+	char *mqttPort = 0;
+	for (int i = 0; i < argc; i++)
+	{
+		if (strlen(argv[i]) >= strlen(BROKER_SWITCH) && strncmp(argv[i], BROKER_SWITCH, strlen(BROKER_SWITCH)) == 0)
+		{
+			mqttBroker = argv[i]+2;
+		}
+		else if (strlen(argv[i]) >= strlen(PORT_SWITCH) && strncmp(argv[i], PORT_SWITCH, strlen(PORT_SWITCH)) == 0)
+		{
+			mqttPort = argv[i]+2;
+		}
+		else if (strlen(argv[i]) >= strlen(TOPIC_SWITCH) && strncmp(argv[i], TOPIC_SWITCH, strlen(TOPIC_SWITCH)) == 0)
+		{
+			mqttTopic = argv[i]+2;
+		}
+	}
 
-    return 0;
-}
+	//Control arguments validity
+	if(!mqttPort || !mqttBroker || !mqttTopic || strlen(mqttPort) == 0 || strlen(mqttBroker) == 0 || strlen(mqttTopic) == 0 || isdigit(mqttPort[0]) == 0)
+	{
+		return ERROR_RETURN;
+	}
+
+	RCSwitch mySwitch;
+	MqttWrapper *mqtt;
+	bool reading = false;
+	pthread_t threadedListenerThread;
+
+	mqtt = new MqttWrapper(SNIFFER_MQTT_ID, mqttTopic, mqttBroker, atoi(mqttPort));
+	mySwitch.enableReceive(PIN);
+
+	while(1)
+	{
+		if(!reading)
+		{
+			currentCode = RCSwitch::popEvent();
+			firstCodeReceivedTime = lastCodeReceivedTime = time(0);
+			if(pthread_create(&threadedListenerThread, NULL, threadedListener, NULL) == 0)
+			{
+				reading = true;
+			}
+		}
+		else
+		{
+			sleep(THRESHOLD);
+			time_t now = time(0);
+			if(now - lastCodeReceivedTime > THRESHOLD)
+			{
+				RCSwitch::pushEvent(0);
+				
+				reading = false;
+			
+				char msg[20], codeStr[20];
+				char *topic;
+
+				topic = (char*)malloc(sizeof(char) * (strlen(mqttTopic) + 20));
+
+				sprintf(codeStr, "%i", currentCode);
+				strcpy(topic, mqttTopic);
+				strcat(topic, "/");
+				strcat(topic, codeStr);
+				sprintf(msg, "%i", lastCodeReceivedTime - firstCodeReceivedTime);
+
+				mqtt->send_message(msg, topic);
+				free(topic);
+				sleep(1);
+			}
+		}
+	}
+	return 0;
+};
+
+void *threadedListener(void *unused){
+	unsigned long code = 1;
+	while(code != 0){
+		code = RCSwitch::popEvent();
+		if(code == currentCode)
+		{
+			lastCodeReceivedTime = time(0);
+		}
+	}
+};

--- a/RPi_utils/RFSniffer.h
+++ b/RPi_utils/RFSniffer.h
@@ -6,14 +6,10 @@
 #define PORT_SWITCH		"-p"
 #define TOPIC_SWITCH	"-t"
 #define ERROR_RETURN	1
-#define DEFAULT_CODE	-1
-#define THRESHOLD		2
 
 // This pin is not the first pin on the RPi GPIO header!
 // Consult https://projects.drogon.net/raspberry-pi/wiringpi/pins/
 // for more information.
 const int PIN = 22;
-
-void *threadedListener(void*);
 
 #endif //_RFSNIFFERH_

--- a/RPi_utils/RFSniffer.h
+++ b/RPi_utils/RFSniffer.h
@@ -1,0 +1,19 @@
+#ifndef _RFSNIFFERH_
+#define _RFSNIFFERH_
+
+#define SNIFFER_MQTT_ID	"RFSniffer"
+#define BROKER_SWITCH	"-b"
+#define PORT_SWITCH		"-p"
+#define TOPIC_SWITCH	"-t"
+#define ERROR_RETURN	1
+#define DEFAULT_CODE	-1
+#define THRESHOLD		2
+
+// This pin is not the first pin on the RPi GPIO header!
+// Consult https://projects.drogon.net/raspberry-pi/wiringpi/pins/
+// for more information.
+const int PIN = 22;
+
+void *threadedListener(void*);
+
+#endif //_RFSNIFFERH_


### PR DESCRIPTION
Do not push 0 events, as they are not considered as received code.

In the return statement of the `receiveProtocolX()`, if the code equals 0, it returns false as 0 is not considered as a valid code. Ignoring 0 codes in the event array is more coherent with the original RCSwitch behavior.
